### PR TITLE
Group Admin Panel Menu Items

### DIFF
--- a/app/Filament/Admin/Resources/DatasetResource.php
+++ b/app/Filament/Admin/Resources/DatasetResource.php
@@ -19,6 +19,7 @@ class DatasetResource extends Resource
     protected static ?string $model = Dataset::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-code-bracket-square';
+    protected static ?string $navigationGroup = 'Survey and Datasets';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Admin/Resources/GlobalIndicatorResource.php
+++ b/app/Filament/Admin/Resources/GlobalIndicatorResource.php
@@ -16,7 +16,8 @@ class GlobalIndicatorResource extends Resource
 {
     protected static ?string $model = GlobalIndicator::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-presentation-chart-bar';
+    protected static ?string $navigationGroup = 'HOLPA Indicators';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Admin/Resources/ThemeResource.php
+++ b/app/Filament/Admin/Resources/ThemeResource.php
@@ -15,7 +15,8 @@ class ThemeResource extends Resource
 {
     protected static ?string $model = Theme::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-squares-2x2';
+    protected static ?string $navigationGroup = 'HOLPA Indicators';
 
     public static function form(Form $form): Form
     {

--- a/app/Filament/Admin/Resources/XlsformTemplateResource.php
+++ b/app/Filament/Admin/Resources/XlsformTemplateResource.php
@@ -18,7 +18,8 @@ class XlsformTemplateResource extends OdkLinkXlsformTemplateResource
 {
     protected static ?string $model = XlsformTemplate::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    protected static ?string $navigationIcon = 'heroicon-o-document-duplicate';
+    protected static ?string $navigationGroup = 'Survey and Datasets';
 
     public static function getRelations(): array
     {


### PR DESCRIPTION
This PR is submitted to fix #45 

It is now ready for review.

It contains below changes:
1. Put 4 menu items into 2 menu groups
2. Change menu item icons

---

Screen shots:

![image](https://github.com/user-attachments/assets/a8d3f6f0-62cb-4fd3-afa6-227c21268697)
