### PR TITLE
Refine Survey Monitoring Page

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -15,6 +15,20 @@ class SubmissionController extends Controller
     {
         // application specific business logic goes here
 
+        // find survey start, survey end, survey duration in minutes
+        $surveyStart = Carbon::parse($submission->content['start']);
+        $surveyEnd = Carbon::parse($submission->content['end']);
+        $surveyDuration = $surveyStart->diffInMinutes($surveyEnd);
+
+        $submission->survey_started_at = $surveyStart;
+        $submission->survey_ended_at = $surveyEnd;
+        $submission->survey_duration = $surveyDuration;
+        $submission->save();
+
+        // skip location levels handling temporary for testing
+        return;
+
+
 
         // find owner (team) of this submission
         $team = $submission->xlsformVersion->xlsform->owner;

--- a/app/Http/Controllers/SurveyMonitoringController.php
+++ b/app/Http/Controllers/SurveyMonitoringController.php
@@ -62,25 +62,18 @@ class SurveyMonitoringController extends Controller
         // find number of farms that completed household form and fieldwork form
         $farmsFullySurveyed = Farm::whereIn('id', $farmsSurveyed)->where('household_form_completed', 1)->where('fieldwork_form_completed', 1)->count();
 
-        // $beneficiaryFarmsSurveyed = $successfulSurveys->filter(fn (Submission $submission) => $submission->content['reg']['farm_id'] !== "-99")->count();
-        // $nonBeneficiaryFarmsSurveyed = $successfulSurveys->filter(fn (Submission $submission) => $submission->content['reg']['farm_id'] === "-99")->count();
-
 
         // hardcode all figures to 0 for testing temporary
         $successfulSurveys = $submissions;
         $surveysWithoutRespondentPresent = 0;
         $surveysWithNonConsentingRespondent = 0;
         $farmsFullySurvey = $farmsFullySurveyed;
-        $beneficiaryFarmsSurveyed = 0;
-        $nonBeneficiaryFarmsSurveyed = 0;
 
 
         return [
             'count' => $count,
             'latestSubmissionDate' => (new Carbon($latestSubmission['createdAt']))->format('Y-m-d H:i:s'),
             'successfulSurveys' => $successfulSurveys->count(),
-            'beneficiaryFarmsSurveyed' => $beneficiaryFarmsSurveyed,
-            'nonBeneficiaryFarmsSurveyed' => $nonBeneficiaryFarmsSurveyed,
             'surveysWithoutRespondentPresent' => $surveysWithoutRespondentPresent,
             'surveysWithNonConsentingRespondent' => $surveysWithNonConsentingRespondent,
             'farmsFullySurvey' => $farmsFullySurvey,

--- a/app/Http/Controllers/SurveyMonitoringController.php
+++ b/app/Http/Controllers/SurveyMonitoringController.php
@@ -2,12 +2,13 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Team;
 use Carbon\Carbon;
+use App\Models\Team;
+use App\Models\SampleFrame\Farm;
 use Illuminate\Support\Facades\Http;
 use Spatie\MediaLibrary\Support\MediaStream;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
 
 class SurveyMonitoringController extends Controller
 {
@@ -54,6 +55,13 @@ class SurveyMonitoringController extends Controller
 
         // $surveysWithNonConsentingRespondent = $submissions->filter(fn (Submission $submission) => $submission->content['consent_grp']['consent'] === "0")->count();
 
+        // TODO: find all farms ID
+        // hardcode temporary for testing
+        $farmsSurveyed = [1, 2];
+
+        // find number of farms that completed household form and fieldwork form
+        $farmsFullySurveyed = Farm::whereIn('id', $farmsSurveyed)->where('household_form_completed', 1)->where('fieldwork_form_completed', 1)->count();
+
         // $beneficiaryFarmsSurveyed = $successfulSurveys->filter(fn (Submission $submission) => $submission->content['reg']['farm_id'] !== "-99")->count();
         // $nonBeneficiaryFarmsSurveyed = $successfulSurveys->filter(fn (Submission $submission) => $submission->content['reg']['farm_id'] === "-99")->count();
 
@@ -62,6 +70,7 @@ class SurveyMonitoringController extends Controller
         $successfulSurveys = $submissions;
         $surveysWithoutRespondentPresent = 0;
         $surveysWithNonConsentingRespondent = 0;
+        $farmsFullySurvey = $farmsFullySurveyed;
         $beneficiaryFarmsSurveyed = 0;
         $nonBeneficiaryFarmsSurveyed = 0;
 
@@ -74,6 +83,7 @@ class SurveyMonitoringController extends Controller
             'nonBeneficiaryFarmsSurveyed' => $nonBeneficiaryFarmsSurveyed,
             'surveysWithoutRespondentPresent' => $surveysWithoutRespondentPresent,
             'surveysWithNonConsentingRespondent' => $surveysWithNonConsentingRespondent,
+            'farmsFullySurvey' => $farmsFullySurvey,
 
         ];
     }

--- a/database/migrations/2024_12_06_151841_add_columns_to_submissions_table.php
+++ b/database/migrations/2024_12_06_151841_add_columns_to_submissions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('submissions', function (Blueprint $table) {
+            $table->timestamp('survey_started_at')->nullable();
+            $table->timestamp('survey_ended_at')->nullable();
+            $table->float('survey_duration')->nullable()->comment('The time difference between survey start time and survey end time in minutes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('submissions', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/filament/app/resources/xlsform-resource/pages/view-xlsform.blade.php
+++ b/resources/views/filament/app/resources/xlsform-resource/pages/view-xlsform.blade.php
@@ -1,29 +1,26 @@
 <x-filament-panels::page
-    @class([
-        'fi-resource-view-record-page',
-        'fi-resource-' . str_replace('/', '-', $this->getResource()::getSlug()),
-        'fi-resource-record-' . $record->getKey(),
+    @class([ 'fi-resource-view-record-page' , 'fi-resource-' . str_replace('/', '-' , $this->getResource()::getSlug()),
+    'fi-resource-record-' . $record->getKey(),
     ])
->
+    >
     @php
-        $relationManagers = $this->getRelationManagers();
-        $hasCombinedRelationManagerTabsWithContent = $this->hasCombinedRelationManagerTabsWithContent();
+    $relationManagers = $this->getRelationManagers();
+    $hasCombinedRelationManagerTabsWithContent = $this->hasCombinedRelationManagerTabsWithContent();
 
 
-        $summary = $this->getSummary();
+    $summary = $this->getSummary();
 
     @endphp
 
     @if ((! $hasCombinedRelationManagerTabsWithContent) || (! count($relationManagers)))
-        @if ($this->hasInfolist())
-            {{ $this->infolist }}
-        @else
-            <div
-                wire:key="{{ $this->getId() }}.forms.{{ $this->getFormStatePath() }}"
-            >
-                {{ $this->form }}
-            </div>
-        @endif
+    @if ($this->hasInfolist())
+    {{ $this->infolist }}
+    @else
+    <div
+        wire:key="{{ $this->getId() }}.forms.{{ $this->getFormStatePath() }}">
+        {{ $this->form }}
+    </div>
+    @endif
     @endif
 
     <div class="grid grid-cols-2 gap-x-8">
@@ -35,20 +32,20 @@
             <p>
                 <b>Number of Live Submissions:</b> {{ $summary['count'] }}
             </p>
-            <br/>
+            <br />
             <p>
                 <b>Number of Completed Surveys:</b> {{ $summary['successfulSurveys'] }}
-                <br/>
+                <br />
                 <small>(Not including non-responses or non-consents)</small>
             </p>
-            <br/>
+            <br />
             <p>
                 <b>Latest Submission:</b> {{ $summary['latestSubmissionDate'] }}
             </p>
-            <br/>
+            <br />
             <p>
                 <b>Submissions In Local Database:</b> {{ count($this->record->submissions) }}
-                <br/>
+                <br />
                 <small>The Live Submissions count above is updated in real time. The number of submissions in the local database may not be fully up to date due to the time it takes to sync with the ODK System.</small>
             </p>
         </x-filament::section>
@@ -66,6 +63,9 @@
                 <b>Surveys With Non-Consenting Respondent</b>
                 <span>{{ $summary['surveysWithNonConsentingRespondent'] }}</span>
 
+                <b>Farms Fully Surveyed</b>
+                <span>{{ $summary['farmsFullySurvey'] }}</span>
+
                 <b>Beneficiary Farms Fully Surveyed:</b>
                 <span>{{ $summary['beneficiaryFarmsSurveyed'] }} / 60 </span>
 
@@ -77,25 +77,24 @@
 
 
     @if (count($relationManagers))
-        <x-filament-panels::resources.relation-managers
-            :active-locale="isset($activeLocale) ? $activeLocale : null"
-            :active-manager="$this->activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
-            :content-tab-label="$this->getContentTabLabel()"
-            :content-tab-icon="$this->getContentTabIcon()"
-            :content-tab-position="$this->getContentTabPosition()"
-            :managers="$relationManagers"
-            :owner-record="$record"
-            :page-class="static::class"
-        >
-            @if ($hasCombinedRelationManagerTabsWithContent)
-                <x-slot name="content">
-                    @if ($this->hasInfolist())
-                        {{ $this->infolist }}
-                    @else
-                        {{ $this->form }}
-                    @endif
-                </x-slot>
+    <x-filament-panels::resources.relation-managers
+        :active-locale="isset($activeLocale) ? $activeLocale : null"
+        :active-manager="$this->activeRelationManager ?? ($hasCombinedRelationManagerTabsWithContent ? null : array_key_first($relationManagers))"
+        :content-tab-label="$this->getContentTabLabel()"
+        :content-tab-icon="$this->getContentTabIcon()"
+        :content-tab-position="$this->getContentTabPosition()"
+        :managers="$relationManagers"
+        :owner-record="$record"
+        :page-class="static::class">
+        @if ($hasCombinedRelationManagerTabsWithContent)
+        <x-slot name="content">
+            @if ($this->hasInfolist())
+            {{ $this->infolist }}
+            @else
+            {{ $this->form }}
             @endif
-        </x-filament-panels::resources.relation-managers>
+        </x-slot>
+        @endif
+    </x-filament-panels::resources.relation-managers>
     @endif
 </x-filament-panels::page>

--- a/resources/views/filament/app/resources/xlsform-resource/pages/view-xlsform.blade.php
+++ b/resources/views/filament/app/resources/xlsform-resource/pages/view-xlsform.blade.php
@@ -66,11 +66,6 @@
                 <b>Farms Fully Surveyed</b>
                 <span>{{ $summary['farmsFullySurvey'] }}</span>
 
-                <b>Beneficiary Farms Fully Surveyed:</b>
-                <span>{{ $summary['beneficiaryFarmsSurveyed'] }} / 60 </span>
-
-                <b>Non-Beneficiary Farms Fully Surveyed:</b>
-                <span>{{ $summary['nonBeneficiaryFarmsSurveyed'] }} / 60</span>
             </div>
         </x-filament::section>
     </div>

--- a/resources/views/submission_summary_wrapper.blade.php
+++ b/resources/views/submission_summary_wrapper.blade.php
@@ -6,6 +6,7 @@ $submissions = $getRecord()->submissions;
 
 
 // comment below code and hardcode temporary for testing
+// TODO: revise to corresponding ODK variable in household form and fieldwork form
 /*
 
 $submissionsByLocations = $submissions->map(function(\Stats4sd\FilamentOdkLink\Models\OdkLink\Submission $submission) {
@@ -28,6 +29,11 @@ return $submission;
 $submissionsByLocations = $submissions;
 $submissionsByEnumerators = $submissions;
 
+$submissionDurationLevel1 = $submissions->whereBetween('survey_duration', [0, 4.999999])->count();
+$submissionDurationLevel2 = $submissions->whereBetween('survey_duration', [5, 29.999999])->count();
+$submissionDurationLevel3 = $submissions->whereBetween('survey_duration', [30, 59.999999])->count();
+$submissionDurationLevel4 = $submissions->whereBetween('survey_duration', [60, 120])->count();
+$submissionDurationLevel5 = $submissions->where('survey_duration', '>', 120)->count();
 
 @endphp
 
@@ -35,30 +41,58 @@ $submissionsByEnumerators = $submissions;
 
     <x-filament::section>
         <x-slot name="heading">
-            <b>Submissions By Location</b>
+            <b>Submissions By Location (TODO)</b>
         </x-slot>
 
+        @foreach($submissionsByLocations as $key => $locationFromSubmission)
         <div class="grid grid-cols-3 gap-3">
-            @foreach($submissionsByLocations as $key => $locationFromSubmission)
             <b class="text-right">{{ $locations->firstWhere('id', $key)?->name ?? $key }}</b>
-            <span class="col-span-2"">{{ $locationFromSubmission->count() }}</span>
-            @endforeach
+            <span class="col-span-2">{{ $locationFromSubmission->count() }}</span>
         </div>
+        @endforeach
 
     </x-filament::section>
 
     <x-filament::section>
-        <x-slot name=" heading">
-                <b>Submissions By Enumerator</b>
-                </x-slot>
+        <x-slot name="heading">
+            <b>Submissions By Enumerator (TODO)</b>
+        </x-slot>
 
-                <div class="grid grid-cols-3 gap-3">
-                    @foreach($submissionsByEnumerators as $key => $enumeratorSubmissions)
-                    <b class="text-right col-span-2">{{ \Illuminate\Support\Str::replace("_", " ", $key) }}</b>
-                    <span>{{ $enumeratorSubmissions->count() }}</span>
-
-                    @endforeach
-                </div>
+        @foreach($submissionsByEnumerators as $key => $enumeratorSubmissions)
+        <div class="grid grid-cols-3 gap-3">
+            <b class="text-right col-span-2">{{ \Illuminate\Support\Str::replace("_", " ", $key) }}</b>
+            <span>{{ $enumeratorSubmissions->count() }}</span>
+        </div>
+        @endforeach
 
     </x-filament::section>
+
+    <x-filament::section>
+        <x-slot name="heading">
+            <b>Submissions By Survey Duration</b>
+        </x-slot>
+
+        <div class="grid grid-cols-3 gap-3">
+            <b class="text-right">0 - 5 Minutes</b>
+            <span class="col-span-2">{{ $submissionDurationLevel1 }}</span>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+            <b class="text-right">5 - 30 Minutes</b>
+            <span class="col-span-2">{{ $submissionDurationLevel2 }}</span>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+            <b class="text-right">30 - 60 Minutes</b>
+            <span class="col-span-2">{{ $submissionDurationLevel3 }}</span>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+            <b class="text-right">60 - 120 Minutes</b>
+            <span class="col-span-2">{{ $submissionDurationLevel4 }}</span>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+            <b class="text-right">&gt; 120 Minutes</b>
+            <span class="col-span-2">{{ $submissionDurationLevel5 }}</span>
+        </div>
+
+    </x-filament::section>
+
 </div>

--- a/resources/views/submission_summary_wrapper.blade.php
+++ b/resources/views/submission_summary_wrapper.blade.php
@@ -36,7 +36,10 @@ $submissionsByEnumerators = $submissions;
 
     <x-filament::section>
         <x-slot name="heading">
-            <b>Submissions By Location (TODO)</b>
+            <!-- TODO -->
+            <!-- refer to below comment in PR 64 -->
+            <!-- https://github.com/stats4sd/holpa-platform/pull/64#pullrequestreview-2513729072 -->
+            <b>Submissions By Location</b>
         </x-slot>
 
         @foreach($submissionsByLocations as $key => $locationFromSubmission)

--- a/resources/views/submission_summary_wrapper.blade.php
+++ b/resources/views/submission_summary_wrapper.blade.php
@@ -7,26 +7,27 @@ $submissions = $getRecord()->submissions;
 
 // comment below code and hardcode temporary for testing
 // TODO: revise to corresponding ODK variable in household form and fieldwork form
-/*
+
 
 $submissionsByLocations = $submissions->map(function(\Stats4sd\FilamentOdkLink\Models\OdkLink\Submission $submission) {
 
-$submission->location_id = $submission->content['reg']['final_location_id'];
+$submission->location_id = $submission->content['context']['location']['village_name'];
 
 return $submission;
 })
 ->groupBy('location_id');
 
+
+/*
 $submissionsByEnumerators = $submissions->map(function(\Stats4sd\FilamentOdkLink\Models\OdkLink\Submission $submission) {
 
 $submission->enumerator_id = $submission->content['survey_start']['inquirer'];
 
 return $submission;
 })->groupBy('enumerator_id');
-
 */
 
-$submissionsByLocations = $submissions;
+
 $submissionsByEnumerators = $submissions;
 
 @endphp
@@ -42,20 +43,6 @@ $submissionsByEnumerators = $submissions;
         <div class="grid grid-cols-3 gap-3">
             <b class="text-right">{{ $locations->firstWhere('id', $key)?->name ?? $key }}</b>
             <span class="col-span-2">{{ $locationFromSubmission->count() }}</span>
-        </div>
-        @endforeach
-
-    </x-filament::section>
-
-    <x-filament::section>
-        <x-slot name="heading">
-            <b>Submissions By Enumerator (TODO)</b>
-        </x-slot>
-
-        @foreach($submissionsByEnumerators as $key => $enumeratorSubmissions)
-        <div class="grid grid-cols-3 gap-3">
-            <b class="text-right col-span-2">{{ \Illuminate\Support\Str::replace("_", " ", $key) }}</b>
-            <span>{{ $enumeratorSubmissions->count() }}</span>
         </div>
         @endforeach
 

--- a/resources/views/submission_summary_wrapper.blade.php
+++ b/resources/views/submission_summary_wrapper.blade.php
@@ -29,12 +29,6 @@ return $submission;
 $submissionsByLocations = $submissions;
 $submissionsByEnumerators = $submissions;
 
-$submissionDurationLevel1 = $submissions->whereBetween('survey_duration', [0, 4.999999])->count();
-$submissionDurationLevel2 = $submissions->whereBetween('survey_duration', [5, 29.999999])->count();
-$submissionDurationLevel3 = $submissions->whereBetween('survey_duration', [30, 59.999999])->count();
-$submissionDurationLevel4 = $submissions->whereBetween('survey_duration', [60, 120])->count();
-$submissionDurationLevel5 = $submissions->where('survey_duration', '>', 120)->count();
-
 @endphp
 
 <div class="grid grid-cols-2 gap-8">
@@ -64,34 +58,6 @@ $submissionDurationLevel5 = $submissions->where('survey_duration', '>', 120)->co
             <span>{{ $enumeratorSubmissions->count() }}</span>
         </div>
         @endforeach
-
-    </x-filament::section>
-
-    <x-filament::section>
-        <x-slot name="heading">
-            <b>Submissions By Survey Duration</b>
-        </x-slot>
-
-        <div class="grid grid-cols-3 gap-3">
-            <b class="text-right">0 - 5 Minutes</b>
-            <span class="col-span-2">{{ $submissionDurationLevel1 }}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-3">
-            <b class="text-right">5 - 30 Minutes</b>
-            <span class="col-span-2">{{ $submissionDurationLevel2 }}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-3">
-            <b class="text-right">30 - 60 Minutes</b>
-            <span class="col-span-2">{{ $submissionDurationLevel3 }}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-3">
-            <b class="text-right">60 - 120 Minutes</b>
-            <span class="col-span-2">{{ $submissionDurationLevel4 }}</span>
-        </div>
-        <div class="grid grid-cols-3 gap-3">
-            <b class="text-right">&gt; 120 Minutes</b>
-            <span class="col-span-2">{{ $submissionDurationLevel5 }}</span>
-        </div>
 
     </x-filament::section>
 


### PR DESCRIPTION
This PR is submitted to fix #51 

It is not yet ready for review. It is submitted for progress update.

It contains below changes:
 - [x] Add 3 new columns in submissions table: survey_started_at, survey_ended_at, survey_duration (in minutes)
 - [x] Show number of farms fully surveyed (with household form completed and fieldwork form completed)
 - [x] Show number of submissions with different survey durations
 - [x] Remove unnecessary items: "Beneficiary Farms", "Non-Beneficiary Farms", "Summary by Survey Duration" section
 - [ ] Revise to show submissions by location (need to find location section in household form and fieldwork form)
 - [ ] Revise to show submissions by enumerator (need to find enumerator section in household form and fieldwork form)

---

Screen shots:

![image](https://github.com/user-attachments/assets/e281ad27-a83d-4322-baa8-b085f5d75e72)
