### PR TITLE
Auto Add Xlsform

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -4,17 +4,18 @@ namespace App\Models;
 
 use App\Models\Locale;
 use App\Models\SampleFrame\Farm;
-use App\Models\XlsformTemplates\ChoiceList;
+use App\Models\Xlsforms\Xlsform;
 use Hoa\Compiler\Llk\Rule\Choice;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Spatie\MediaLibrary\HasMedia;
 use App\Models\SampleFrame\Location;
 use App\Models\SampleFrame\LocationLevel;
-use App\Models\Xlsforms\Xlsform;
+use Illuminate\Database\Eloquent\Builder;
+use App\Models\XlsformTemplates\ChoiceList;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use App\Models\XlsformTemplates\XlsformTemplate;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -50,6 +51,18 @@ class Team extends FilamentTeamManagementTeam implements WithXlsforms, HasMedia
             $owner->locales()->attach($en);
 
 
+            // create xlsform models for all active xlsform template for this new team
+            $xlsformTemplates = XlsformTemplate::where('available', 1)->get();
+
+            // no need to check if team has any xlsform already, suppose a newly created team should have no xlsform
+            foreach ($xlsformTemplates as $xlsformTemplate) {
+                $xlsform = Xlsform::create([
+                    'owner_id' => $owner->id,
+                    'owner_type' => static::class,
+                    'xlsform_template_id' => $xlsformTemplate->id,
+                    'title' => $xlsformTemplate->title,
+                ]);
+            }
         });
     }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -51,10 +51,10 @@ class Team extends FilamentTeamManagementTeam implements WithXlsforms, HasMedia
             $owner->locales()->attach($en);
 
 
-            // create xlsform models for all active xlsform template for this new team
+            // create xlsform models for all active xlsform template for this newly created team
             $xlsformTemplates = XlsformTemplate::where('available', 1)->get();
 
-            // no need to check if team has any xlsform already, suppose a newly created team should have no xlsform
+            // suppose a newly created team does not have any xlsform, it is not necessary to do checking
             foreach ($xlsformTemplates as $xlsformTemplate) {
                 $xlsform = Xlsform::create([
                     'owner_id' => $owner->id,


### PR DESCRIPTION
This PR is submitted to fix #49 

It is now ready for review.

It contains below changes:
- [x] When a new team is created, create Xlsform model for all available xlsform templates to this team
- [x] When a xlsform template is marked as "Available for use", create Xlsform model for teams that do not have this xlsform template yet

---

P.S. I created this branch based on branch "add-data-export". As I think "add-data-export" should have latest code to have minimum merge conflicts.... But it seems complicated if merge to dev branch, so I set this PR to merge into "add-data-export" branch first. It is easier to see the code changes only for this PR.