### PR TITLE
Links diet diversity with country

### DIFF
--- a/app/Filament/App/Pages/DietDiversity.php
+++ b/app/Filament/App/Pages/DietDiversity.php
@@ -37,6 +37,16 @@ class DietDiversity extends Page implements HasForms, HasTable
 
     public function form(Form $form): Form
     {
+        // If the team's `diet_diversity_module_version_id` is null, set the default using the team's country
+        if (is_null($this->team->diet_diversity_module_version_id)) {
+            $this->team->diet_diversity_module_version_id = XlsformModuleVersion::query()
+                ->whereHas('xlsformModule', fn($query) => $query->where('name', 'diet_quality'))
+                ->where('country_id', $this->team->country_id)
+                ->value('id');
+
+            $this->team->save();
+        }
+
         return $form
             ->statePath('data')
             ->model($this->team)

--- a/app/Models/Reference/Country.php
+++ b/app/Models/Reference/Country.php
@@ -29,7 +29,7 @@ class Country extends Model
         return $this->hasMany(Team::class);
     }
 
-    public function xlsformModuleVersion(): HasMany
+    public function xlsformModuleVersions(): HasMany
     {
         return $this->hasMany(XlsformModuleVersion::class);
     }

--- a/app/Models/Reference/Country.php
+++ b/app/Models/Reference/Country.php
@@ -4,9 +4,9 @@ namespace App\Models\Reference;
 
 use App\Models\Team;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Znck\Eloquent\Traits\BelongsToThrough;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Country extends Model
 {
@@ -27,5 +27,10 @@ class Country extends Model
     public function teams(): HasMany
     {
         return $this->hasMany(Team::class);
+    }
+
+    public function xlsformModuleVersion(): HasMany
+    {
+        return $this->hasMany(XlsformModuleVersion::class);
     }
 }

--- a/app/Models/Xlsforms/XlsformModuleVersion.php
+++ b/app/Models/Xlsforms/XlsformModuleVersion.php
@@ -2,24 +2,25 @@
 
 namespace App\Models\Xlsforms;
 
-use App\Models\Interfaces\WithXlsformFile;
 use App\Models\Team;
-use App\Models\XlsformLanguages\Language;
-use App\Models\XlsformLanguages\Locale;
-use App\Models\XlsformLanguages\XlsformModuleVersionLocale;
-use App\Services\XlsformTranslationHelper;
-use Illuminate\Console\View\Components\Choice;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Support\Collection;
+use App\Models\Reference\Country;
 use Spatie\MediaLibrary\HasMedia;
+use Illuminate\Support\Collection;
+use App\Models\XlsformLanguages\Locale;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\XlsformLanguages\Language;
+use App\Models\Interfaces\WithXlsformFile;
+use App\Services\XlsformTranslationHelper;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Illuminate\Console\View\Components\Choice;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use App\Models\XlsformLanguages\XlsformModuleVersionLocale;
 
 class XlsformModuleVersion extends Model implements HasMedia
 {
@@ -45,6 +46,11 @@ class XlsformModuleVersion extends Model implements HasMedia
     public function xlsformModule(): BelongsTo
     {
         return $this->belongsTo(XlsformModule::class);
+    }
+
+    public function country(): BelongsTo
+    {
+        return $this->belongsTo(Country::class);
     }
 
     // Which teams have selected to use this module instead of the default?

--- a/database/migrations/2025_01_09_131155_add_country_id_to_xlsform_module_versions_table.php
+++ b/database/migrations/2025_01_09_131155_add_country_id_to_xlsform_module_versions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('xlsform_module_versions', function (Blueprint $table) {
+            $table->foreignId('country_id')->nullable()->after('is_default');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('xlsform_module_versions', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
This PR:
- adds country_id on xlsform_module_versions
- sets up the link between the two models
- updates the diet diversity page to set the country's diet diversity module as the default for the team if there is no diet diversity module selected