### PR TITLE
Register ODK Link resources on admin panel

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -18,6 +18,7 @@ use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Stats4sd\FilamentOdkLink\OdkLinkAdmin;
 use Stats4sd\FilamentTeamManagement\Http\Middleware\CheckIfAdmin;
 use Stats4sd\FilamentTeamManagement\Filament\Admin\Resources\UserResource;
 
@@ -71,6 +72,8 @@ class AdminPanelProvider extends PanelProvider
                     ->url(url('/app'))
                     ->sort(1),
             ])->darkMode(false)
-            ->plugins([]);
+            ->plugins([
+                OdkLinkAdmin::make(),
+            ]);
     }
 }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -20,6 +20,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Stats4sd\FilamentOdkLink\OdkLinkAdmin;
 use Stats4sd\FilamentTeamManagement\Filament\App\Pages\RegisterTeam;
 use Stats4sd\FilamentTeamManagement\Http\Middleware\SetLatestTeamMiddleware;
 


### PR DESCRIPTION
Due to the new way to register resources / pages from the ODK Link package, the admin panel no longer contained the Xlsform-related pages. This PR fixes that. 