### PR TITLE
LISP UI Refinements

### DIFF
--- a/app/Livewire/GlobalIndicators.php
+++ b/app/Livewire/GlobalIndicators.php
@@ -71,7 +71,8 @@ class GlobalIndicators extends Component implements HasForms, HasTable
             ->relationship(fn() => $query)
             ->columns([
                 TextColumn::make('name')
-                    ->label(''),
+                    ->label('')
+                    ->wrap(),
             ])
             ->recordClasses(fn(GlobalIndicator $record): string => $this->selectedLocalIndicator->globalIndicator?->id === $record->id ? 'font-bold bg-lightgreen' : '')
             ->actions([
@@ -118,7 +119,6 @@ class GlobalIndicators extends Component implements HasForms, HasTable
                             ->body('Match removed!')
                             ->success()
                             ->send();
-
                     }),
 
                 Action::make('already_matched')


### PR DESCRIPTION
This PR is submitted to 
fix #221 
fix #222 
fix #224 

It is not yet ready for review. It is submitted for progress update.

It contains below changes:
 - [x] LISP, match with existing global indicators page, wrap global indicator in table cell
 - [ ] LISP, match with existing global indicators page, do not show empty column header
 - [ ] LISP, add custom survey questions, refine UI to show questions in tabular format, click to show details in popup modal