### PR TITLE
Create xlsform module version as soon as local indicator is created;

### DIFF
--- a/app/Models/Holpa/LocalIndicator.php
+++ b/app/Models/Holpa/LocalIndicator.php
@@ -16,6 +16,21 @@ class LocalIndicator extends Model
 
     protected $guarded = ['id'];
 
+    protected static function booted()
+    {
+        static::created(function (self $localIndicator) {
+            $xlsformModuleVersion = $localIndicator->xlsformModuleVersion()->create([
+                'owner_id' => $localIndicator->team_id,
+                'name' => $localIndicator->name,
+                'is_default' => false,
+            ]);
+
+            // I have no idea why the above doesn't automatically associate the new module version with the current local indicator...
+            $localIndicator->xlsformModuleVersion()->associate($xlsformModuleVersion);
+            $localIndicator->save();
+        });
+    }
+
     public function domain(): BelongsTo
     {
         return $this->belongsTo(Domain::class);

--- a/resources/views/livewire/custom-module-ordering.blade.php
+++ b/resources/views/livewire/custom-module-ordering.blade.php
@@ -58,8 +58,6 @@
                             'bg-slate-200 border-slate-900' => $xlsformModuleVersion->owner?->id === $team->id,
                             ])
                         >
-                            Owner: {{ $xlsformModuleVersion?->owner?->name }}<br/>
-                            Current Team {{ $team?->name }}<br/>
 
                             @foreach($xlsformModuleVersion->surveyRows as $surveyRow)
                                 <div class="flex items-center">{{ $surveyRow->name }} ( {{ $surveyRow->type }} )</div>

--- a/resources/views/livewire/custom-module-ordering.blade.php
+++ b/resources/views/livewire/custom-module-ordering.blade.php
@@ -58,6 +58,8 @@
                             'bg-slate-200 border-slate-900' => $xlsformModuleVersion->owner?->id === $team->id,
                             ])
                         >
+                            Owner: {{ $xlsformModuleVersion?->owner?->name }}<br/>
+                            Current Team {{ $team?->name }}<br/>
 
                             @foreach($xlsformModuleVersion->surveyRows as $surveyRow)
                                 <div class="flex items-center">{{ $surveyRow->name }} ( {{ $surveyRow->type }} )</div>


### PR DESCRIPTION
Fixes #231. 

The module ordering page is setup so that any 'global' module cannot be moved. A module is deemed global if it is not owned by any team. The issue was caused because the modules created for the team's local indicators were not properly assigned to the team. 

@emilynevitt - this fix will only affect new local indicators, so if you create a new one, you should be able to move it around even after dragging it into the right-hand list. 