### PR TITLE
Fix Default Translation Description

### DIFF
--- a/database/seeders/TestMiniForms/LocaleSeeder.php
+++ b/database/seeders/TestMiniForms/LocaleSeeder.php
@@ -19,15 +19,17 @@ class LocaleSeeder extends Seeder
             ->locales()
             ->create([
                 'is_default' => true,
+                'description' => 'English (Default)',
             ]);
 
         $localeEs = Language::firstWhere('iso_alpha2', 'es')
             ->locales()
             ->create([
                 'is_default' => true,
+                'description' => 'Spanish (Default)',
             ]);
 
-        Team::all()->each(function(Team $team) use ($localeEs, $localeEn) {
+        Team::all()->each(function (Team $team) use ($localeEs, $localeEn) {
             $team->languages()->updateExistingPivot($localeEn->language->id, ['locale_id' => $localeEn->id]);
 
             $team->languages()->updateExistingPivot($localeEs->language->id, ['locale_id' => $localeEs->id]);

--- a/database/seeders/TestMiniForms/LocaleSeeder.php
+++ b/database/seeders/TestMiniForms/LocaleSeeder.php
@@ -19,14 +19,12 @@ class LocaleSeeder extends Seeder
             ->locales()
             ->create([
                 'is_default' => true,
-                'description' => 'English (Default)',
             ]);
 
         $localeEs = Language::firstWhere('iso_alpha2', 'es')
             ->locales()
             ->create([
                 'is_default' => true,
-                'description' => 'Spanish (Default)',
             ]);
 
         Team::all()->each(function (Team $team) use ($localeEs, $localeEn) {

--- a/database/seeders/TestRealForms/LocalesTableSeeder.php
+++ b/database/seeders/TestRealForms/LocalesTableSeeder.php
@@ -24,7 +24,6 @@ class LocalesTableSeeder extends Seeder
             ->locales()
             ->create([
                 'is_default' => true,
-                'description' => 'English (Default)',
             ]);
 
         Team::all()->each(function (Team $team) use ($localeEn) {

--- a/database/seeders/TestRealForms/LocalesTableSeeder.php
+++ b/database/seeders/TestRealForms/LocalesTableSeeder.php
@@ -24,11 +24,11 @@ class LocalesTableSeeder extends Seeder
             ->locales()
             ->create([
                 'is_default' => true,
+                'description' => 'English (Default)',
             ]);
 
         Team::all()->each(function (Team $team) use ($localeEn) {
             $team->languages()->updateExistingPivot($localeEn->language->id, ['locale_id' => $localeEn->id]);
         });
-
     }
 }

--- a/resources/views/livewire/team-translation-entry.blade.php
+++ b/resources/views/livewire/team-translation-entry.blade.php
@@ -4,7 +4,7 @@
             <h6 class="w-full md:w-1/2 lg:w-1/4 ">{{ $language->language_label }}</h6>
             <h5 class="w-full md:w-1/2 lg:w-3/4 md:flex items-center ">
                 <span class="mr-2">Selected Translation: </span>
-                <span class="{{ $selectedLocale ? 'text-green' : 'text-dark-orange' }}">{{ $selectedLocale ? $selectedLocale->description : 'none' }}</span>
+                <span class="{{ $selectedLocale ? 'text-green' : 'text-dark-orange' }}">{{ $selectedLocale ? $selectedLocale->languageLabel : 'none' }}</span>
             </h5>
 
         </div>
@@ -13,11 +13,11 @@
             <button class=" text-nowrap flex text-black  items-center  justify-between " wire:click="$toggle('expanded')">
                 Select Translation
                 @if($expanded)
-                <x-heroicon-o-chevron-up class="h-6 ml-4 font-bold text-lg "/>
+                <x-heroicon-o-chevron-up class="h-6 ml-4 font-bold text-lg " />
                 @else
-                <x-heroicon-o-chevron-down class="h-6 ml-4 font-bold text-lg "/>
+                <x-heroicon-o-chevron-down class="h-6 ml-4 font-bold text-lg " />
                 @endif
-                </button>
+            </button>
         </div>
     </div>
 


### PR DESCRIPTION
This PR is submitted to fix issue #215 

It is now ready for review.

It contains below changes:
 - [x] Add locales.description in seeder files

Questions:
1. We created locales records for default translations in seeder files. Is there any other scenario in application to do the same? We will need to fill in locales.description as [language name] + (Default).

---

Screen shots:

After running seeder files for mini forms:
![image](https://github.com/user-attachments/assets/bcc01dad-10cd-4ea0-9fdd-474495e1bba3)
