### PR TITLE
File upload experience

### DIFF
--- a/app/Livewire/Lisp/CustomModuleVersions.php
+++ b/app/Livewire/Lisp/CustomModuleVersions.php
@@ -64,13 +64,18 @@ class CustomModuleVersions extends Component implements HasForms
                             ->acceptedFileTypes(['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel']) // Accept only Excel files
                             ->maxSize(10240)
                             ->preserveFilenames()
+                            ->label(fn($state) => count($state) === 0
+                                ? 'Upload your completed Xlsform file with the custom questions for your indicators.'
+                                : 'To upload a new set of questions, delete the existing file with the "x" icon below and upload the new completed file.'
+                            )
                             ->helperText(fn(self $livewire) => new HtmlString('<span class="text-red-700">' . collect($livewire->getErrorBag()->get('local_indicator_list'))->join('<br/>') . '</span>')),
                         Actions::make([
                             Action::make('save_file')
                                 ->label('Save File')
                                 ->extraAttributes(['class' => 'buttona'])
                                 ->action(fn(Get $get) => $this->uploadFile($get('custom_questions_file'))),
-                        ]),
+                        ])
+                        ->extraAttributes(['class']),
                     ]),
             ]);
     }
@@ -95,6 +100,9 @@ class CustomModuleVersions extends Component implements HasForms
             foreach ($moduleVersions as $moduleVersion) {
                 $handler->processXlsformTemplate($file->getRealPath(), $moduleVersion, 'indicator');
             }
+
+            $this->team->addMedia($file)->toMediaCollection('custom_questions');
+
         } catch (Exception $e) {
             $this->addError('local_indicator_list', 'An error occurred while uploading the file.');
         }

--- a/app/Livewire/Lisp/UploadLocalIndicators.php
+++ b/app/Livewire/Lisp/UploadLocalIndicators.php
@@ -67,14 +67,17 @@ class UploadLocalIndicators extends Component implements HasForms, HasTable
                             ->acceptedFileTypes(['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel']) // Accept only Excel files
                             ->maxSize(10240)
                             ->preserveFilenames()
-                            ->helperText(fn (self $livewire) => new HtmlString('<span class="text-red-700">'.collect($livewire->getErrorBag()->get('local_indicator_list'))->join('<br/>').'</span>')),
+                            ->label(fn($state) => count($state) === 0
+                                ? 'Upload your list of local indicators here.'
+                                : 'To upload a new set of indicators, delete the existing file with the "x" icon below and upload the new completed file.'
+                            )
+                            ->helperText(fn(self $livewire) => new HtmlString('<span class="text-red-700">' . collect($livewire->getErrorBag()->get('local_indicator_list'))->join('<br/>') . '</span>')),
 
                         Actions::make([
                             Actions\Action::make('save_file')
                                 ->extraAttributes(['class' => ' buttona'])
-
                                 ->label('Save File')
-                                ->action(fn (Get $get) => $this->uploadFile($get('local_indicator_list'))),
+                                ->action(fn(Get $get) => $this->uploadFile($get('local_indicator_list'))),
                         ]),
                     ]),
                 Fieldset::make('Local Indicators List')
@@ -109,7 +112,7 @@ class UploadLocalIndicators extends Component implements HasForms, HasTable
     public function uploadFile($localIndicatorList): void
     {
         // Check that a file is uploaded
-        if (empty($localIndicatorList) || ! is_array($localIndicatorList)) {
+        if (empty($localIndicatorList) || !is_array($localIndicatorList)) {
             $this->addError('local_indicator_list', 'Please upload a file before proceeding.');
 
             return;
@@ -124,6 +127,8 @@ class UploadLocalIndicators extends Component implements HasForms, HasTable
 
             $this->team->refresh();
             $this->form->fill($this->team->toArray());
+
+            $this->team->addMedia($file)->toMediaCollection('local_indicators');
 
             // Display success message
             Notification::make()
@@ -145,9 +150,9 @@ class UploadLocalIndicators extends Component implements HasForms, HasTable
                     return "Row $keyRow, Column $keyColumn: $errors";
                 });
 
-            ray(new HtmlString('It looks like the file you uploaded is not valid. Please check the file and try again. Errors Found: <br/><br/>'.$errors->join('<br/>')));
+            ray(new HtmlString('It looks like the file you uploaded is not valid. Please check the file and try again. Errors Found: <br/><br/>' . $errors->join('<br/>')));
 
-            $this->addError('local_indicator_list', 'It looks like the file you uploaded is not valid. Please check the file and try again. Errors Found: <br/><br/>'.$errors->join('<br/>'));
+            $this->addError('local_indicator_list', 'It looks like the file you uploaded is not valid. Please check the file and try again. Errors Found: <br/><br/>' . $errors->join('<br/>'));
         } catch (Exception $e) {
             $this->addError('local_indicator_list', 'An error occurred while uploading the file.');
         }

--- a/app/Livewire/SurveyLanguages/TeamTranslationReviewEditForm.php
+++ b/app/Livewire/SurveyLanguages/TeamTranslationReviewEditForm.php
@@ -44,38 +44,38 @@ class TeamTranslationReviewEditForm extends Component implements HasActions, Has
             ->model($this->locale)
             ->columns(2)
             ->schema(
-                fn (): array => $this->team->xlsforms->map(fn (Xlsform $xlsform) => $xlsform->xlsformTemplate)
+                fn(): array => $this->team->xlsforms->map(fn(Xlsform $xlsform) => $xlsform->xlsformTemplate)
                     ->map(
-                        fn (XlsformTemplate $xlsformTemplate) => Section::make($xlsformTemplate->title)
+                        fn(XlsformTemplate $xlsformTemplate) => Section::make($xlsformTemplate->title)
                             ->schema([
                                 Actions::make([
 
                                     // download existing translations if they exist
-                                    Actions\Action::make('download_'.$xlsformTemplate->id)
+                                    Actions\Action::make('download_' . $xlsformTemplate->id)
                                         // ->link()
                                         ->label('Download existing translations')
                                         ->extraAttributes(['class' => 'buttona w-full'])
-                                        ->action(fn () => Excel::download(new XlsformTemplateTranslationsExport($xlsformTemplate, $this->locale), "{$xlsformTemplate->title} translation - {$this->locale->language_label}.xlsx")),
+                                        ->action(fn() => Excel::download(new XlsformTemplateTranslationsExport($xlsformTemplate, $this->locale), "{$xlsformTemplate->title} translation - {$this->locale->language_label}.xlsx")),
 
                                     // download blank template if needed
-                                    Actions\Action::make('download_'.$xlsformTemplate->id)
+                                    Actions\Action::make('download_' . $xlsformTemplate->id)
                                         ->extraAttributes(['class' => 'buttona w-full'])
-                                        ->visible(fn () => $this->locale->is_editable)
+                                        ->visible(fn() => $this->locale->is_editable)
                                         ->label('Download empty translation template')
-                                        ->action(fn () => Excel::download(new XlsformTemplateTranslationsExport($xlsformTemplate, $this->locale, empty: true), "{$xlsformTemplate->title} translation - {$this->locale->language_label}.xlsx")),
+                                        ->action(fn() => Excel::download(new XlsformTemplateTranslationsExport($xlsformTemplate, $this->locale, empty: true), "{$xlsformTemplate->title} translation - {$this->locale->language_label}.xlsx")),
                                 ]),
-                                SpatieMediaLibraryFileUpload::make('upload_for_template_'.$xlsformTemplate->id)
+                                SpatieMediaLibraryFileUpload::make('upload_for_template_' . $xlsformTemplate->id)
                                     ->collection('xlsform_template_translation_files')
-                                    ->filterMediaUsing(fn (Collection $media) => $media->where('custom_properties.xlsform_template_id', $xlsformTemplate->id))
+                                    ->filterMediaUsing(fn(Collection $media) => $media->where('custom_properties.xlsform_template_id', $xlsformTemplate->id))
                                     ->customProperties(['xlsform_template_id' => $xlsformTemplate->id])
-                                    ->visible(fn () => $this->locale->is_editable)
-                                    ->label("Upload completed {$xlsformTemplate->title} translation file")
+                                    ->visible(fn() => $this->locale->is_editable)
+                                    ->live()
+                                    ->label(fn($state) => count($state) === 0
+                                        ? "Upload completed {$xlsformTemplate->title} translation file"
+                                        : "To replace the translations, delete the existing file with the 'x' icon below and upload the new completed translations file."
+                                    )
                                     ->acceptedFileTypes(['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel']) // Accept only Excel files
-                                    ->maxSize(10240)
-                                //                                        ->rules([
-                                //                                            fn(Get $get, Locale $record) => $this->validateFileUpload($get('upload_for_template_' . $xlsformTemplate->id), $record, $xlsformTemplate),
-                                //                                        ]),
-                                ,
+                                    ->maxSize(10240),
                             ])
                             ->columnSpan(1),
                     )->toArray(),
@@ -96,7 +96,7 @@ class TeamTranslationReviewEditForm extends Component implements HasActions, Has
             })->first();
 
             // if the file doesn't exist, don't process it.
-            if (! $file) {
+            if (!$file) {
                 continue;
             }
 
@@ -113,7 +113,7 @@ class TeamTranslationReviewEditForm extends Component implements HasActions, Has
     {
         // copy this locale as a new locale model
         $newRecord = $this->locale->replicate();
-        $newRecord->description = $this->locale->languageLabel.' - duplicated';
+        $newRecord->description = $this->locale->languageLabel . ' - duplicated';
         $newRecord->is_default = false;
         $newRecord->creator()->associate($this->team);
         $newRecord->save();


### PR DESCRIPTION
Fixes #220.

- The decision is to keep the file visible in the upload fields for:
    - Translations
    - Local Indicators
    - Local Indicator Xlsform Questions

This way, users can see if a file has been completed / uploaded. They may download that file, or replace it with another file. It also means these file uploads have consistent functionality.
