### PR TITLE
Refine Local Indicator Table

### DIFF
--- a/resources/views/livewire/lisp/upload-local-indicators.blade.php
+++ b/resources/views/livewire/lisp/upload-local-indicators.blade.php
@@ -12,15 +12,17 @@
     <div class="py-4 indicator-upload">
         <div class="mx-auto  ">
             <div class="p-6 bg-white  ">
+                <!-- local indicator excel template file upload file -->
                 {{ $this->form }}
             </div>
 
-            <div class="flex justify-center mt-6">
-                <button wire:click="saveIndicators"
-                        class="buttona">
-                    Save
-                </button>
+            <div class="p-6 bg-white  ">
+                <!-- allow user to maintain local indicators (uploaded or manually created) in a table -->
+                {{ $this->table }}
             </div>
+
         </div>
     </div>
+
+
 </div>


### PR DESCRIPTION
This PR is submitted to fix #226 

It is now ready for review.

It contains below changes:
 - [x] apply a simpler and comprimised way to refine local indicator table for user editing

---

I tried to have two separate forms in UploadLocalIndicators.php but failed. Therefore I tried to find another feasible way to fulfill the requirement.

The original table() function in UploadLocalIndicators.php seems not being used anywhere in application. I modified it to allow user to maintain local indicator records (add / edit / delete).

Pros: This is the same way for how user maintains custom questions (more consistent)
Cons: User can only add / edit / delete one record each time (Um... from another point of view, this may be a better way to avoid user making many changes at once, as they may forget what they did...)

---

Screen shots:

Table to add / edit / delete one local indicator at one time
![image](https://github.com/user-attachments/assets/4f40640b-576d-4f96-9513-6a30d083d07b)

Popup modal for editing
![image](https://github.com/user-attachments/assets/6a0c5031-a574-45c4-acb1-27890696cefa)

The same approach that aligned with how user maintains custom questions
![image](https://github.com/user-attachments/assets/b81cf818-9fa2-4c8d-9592-04a975cc3c66)
