### PR TITLE
Fix Custom Question Default Label

### DIFF
--- a/app/Livewire/Lisp/CustomModuleVersions.php
+++ b/app/Livewire/Lisp/CustomModuleVersions.php
@@ -15,12 +15,14 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
+use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\HtmlString;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Maatwebsite\Excel\Facades\Excel;
 use Stats4sd\FilamentOdkLink\Listeners\HandleXlsformTemplateAdded;
 
@@ -64,18 +66,20 @@ class CustomModuleVersions extends Component implements HasForms
                             ->acceptedFileTypes(['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel']) // Accept only Excel files
                             ->maxSize(10240)
                             ->preserveFilenames()
-                            ->label(fn($state) => count($state) === 0
-                                ? 'Upload your completed Xlsform file with the custom questions for your indicators.'
-                                : 'To upload a new set of questions, delete the existing file with the "x" icon below and upload the new completed file.'
+                            ->label(
+                                fn($state) => count($state) === 0
+                                    ? 'Upload your completed Xlsform file with the custom questions for your indicators.'
+                                    : 'To upload a new set of questions, delete the existing file with the "x" icon below and upload the new completed file.'
                             )
                             ->helperText(fn(self $livewire) => new HtmlString('<span class="text-red-700">' . collect($livewire->getErrorBag()->get('local_indicator_list'))->join('<br/>') . '</span>')),
                         Actions::make([
-                            Action::make('save_file')
-                                ->label('Save File')
+                            Actions\Action::make('save_file')
                                 ->extraAttributes(['class' => 'buttona'])
+                                ->label('Save File')
                                 ->action(fn(Get $get) => $this->uploadFile($get('custom_questions_file')))
-                            ->disabled(fn(Get $get) => ! collect($get('custom_questions_file'))->first() instanceof TemporaryUplo),
-                        ]),
+                                ->disabled(fn(Get $get) => ! collect($get('custom_questions_file'))->first() instanceof TemporaryUploadedFile),
+                        ])
+                            ->extraAttributes(['class' => 'flex justify-center']),
                     ]),
             ]);
     }
@@ -103,6 +107,12 @@ class CustomModuleVersions extends Component implements HasForms
 
             $this->team->addMedia($file)->toMediaCollection('custom_questions');
 
+            // Display success message
+            Notification::make()
+                ->title('File uploaded successfully!')
+                ->body('The file will be processed in the background and the questions will appear below once complete. You may leave this page without interrupting this process.') // TODO: listen for server-side event nad refresh the list of questions when the import jobs complete!
+                ->success()
+                ->send();
         } catch (Exception $e) {
             $this->addError('local_indicator_list', 'An error occurred while uploading the file.');
         }

--- a/app/Livewire/Lisp/LocalIndicatorQuestionForm.php
+++ b/app/Livewire/Lisp/LocalIndicatorQuestionForm.php
@@ -107,7 +107,9 @@ class LocalIndicatorQuestionForm extends Component implements HasActions, HasFor
             ->columns([
                 TextColumn::make('type')->label('Question Type'),
                 TextColumn::make('name')->label('Variable Name'),
-                TextColumn::make('defaultLabel')->label('Default Label'),
+
+                // fix to show default label as string instead of a JSON array
+                TextColumn::make('defaultLabel.text')->label('Default Label'),
             ])
             // allow user to change the ordering by drag and drop
             ->reorderable('row_number')


### PR DESCRIPTION
This PR is submitted to fix #247 

It is not yet ready for review. It is submitted for progress update.

It contains below changes:
 - [x] fix to show custom question (created manully) default label as a string instead of a JSON array
 - [x] fix to add default label when uploading excel file that contains custom question details

---

After applying a fix to show manually created custom question default label properly. I tried to upload excel file with custom questions. It is strange that the "SAVE FILE" button is not enabled after uploading the file.

I did a testing in "Upload local indicators" page, the file upload works fine... not sure why it does not work in "Add custom survey questions" page...

I will move to work on issue 199 first.

---

Screen shots:

"Add custom survey questions" page, "SAVE FILE" button not enabled after uploading file
![image](https://github.com/user-attachments/assets/9d6ec85e-4df4-4eda-ad99-cc18b03c1e05)

"Upload local indicators" page, "SAVE FILE" button enabled after uploading file
![image](https://github.com/user-attachments/assets/2bcc6662-1a19-472a-85ba-a03083ad087b)
