### PR TITLE
Diet diversity modules

### DIFF
--- a/app/Filament/Admin/Resources/DietDiversityModuleVersionResource.php
+++ b/app/Filament/Admin/Resources/DietDiversityModuleVersionResource.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Filament\Admin\Resources;
+
+use App\Filament\Admin\Resources\DietDiversityModuleVersionResource\Pages;
+use App\Filament\Admin\Resources\DietDiversityModuleVersionResource\RelationManagers;
+use App\Models\DietDiversityModuleVersion;
+use Awcodes\Shout\Components\Shout;
+use Filament\Forms;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Stats4sd\FilamentOdkLink\Models\Country;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModule;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
+
+class DietDiversityModuleVersionResource extends Resource
+{
+    protected static ?string $model = XlsformModuleVersion::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-globe-europe-africa';
+
+    protected static ?string $navigationGroup = 'ODK Forms and Datasets';
+    protected static ?string $navigationLabel = 'Diet Diversity Module Versions';
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereHas('xlsformModule', function (Builder $query) {
+                $query->where('xlsform_modules.name', 'diet_diversity');
+            });
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Hidden::make('xlsform_module_id')
+                    ->default(XlsformModule::where('name', 'diet_diversity')->first()?->id),
+                Forms\Components\Select::make('country_id')
+                    ->live()
+                    ->searchable()
+                    ->preload()
+                    ->required()
+                    ->relationship('country', 'name')
+                    ->label('Which country is this Diet Diversity module for?')
+                    ->afterStateUpdated(fn(Forms\Set $set, ?string $state) => $set('name', 'diet_diversity ' . Country::find($state)?->name)),
+                Hidden::make('name'),
+                Forms\Components\SpatieMediaLibraryFileUpload::make('xlsfile')
+                    ->required()
+                    ->label('Upload Xlsfile with the module questions.')
+                    ->collection('xlsform_file')
+                    ->preserveFilenames()
+                    ->downloadable()
+                    ->visible(fn(Forms\Get $get): bool => !$get('is_default'))
+                    ->placeholder(__('File')),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')->sortable(),
+                IconColumn::make('is_default')->sortable()
+                    ->boolean(),
+                TextColumn::make('country.name')->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDietDiversityModuleVersions::route('/'),
+            'create' => Pages\CreateDietDiversityModuleVersion::route('/create'),
+            'edit' => Pages\EditDietDiversityModuleVersion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/DietDiversityModuleVersionResource/Pages/CreateDietDiversityModuleVersion.php
+++ b/app/Filament/Admin/Resources/DietDiversityModuleVersionResource/Pages/CreateDietDiversityModuleVersion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DietDiversityModuleVersionResource\Pages;
+
+use App\Filament\Admin\Resources\DietDiversityModuleVersionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDietDiversityModuleVersion extends CreateRecord
+{
+    protected static string $resource = DietDiversityModuleVersionResource::class;
+}

--- a/app/Filament/Admin/Resources/DietDiversityModuleVersionResource/Pages/EditDietDiversityModuleVersion.php
+++ b/app/Filament/Admin/Resources/DietDiversityModuleVersionResource/Pages/EditDietDiversityModuleVersion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DietDiversityModuleVersionResource\Pages;
+
+use App\Filament\Admin\Resources\DietDiversityModuleVersionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDietDiversityModuleVersion extends EditRecord
+{
+    protected static string $resource = DietDiversityModuleVersionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/DietDiversityModuleVersionResource/Pages/ListDietDiversityModuleVersions.php
+++ b/app/Filament/Admin/Resources/DietDiversityModuleVersionResource/Pages/ListDietDiversityModuleVersions.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\DietDiversityModuleVersionResource\Pages;
+
+use App\Filament\Admin\Resources\DietDiversityModuleVersionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDietDiversityModuleVersions extends ListRecords
+{
+    protected static string $resource = DietDiversityModuleVersionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/App/Pages/PlaceAdaptations/DietDiversity.php
+++ b/app/Filament/App/Pages/PlaceAdaptations/DietDiversity.php
@@ -74,7 +74,7 @@ class DietDiversity extends Page implements HasForms, HasTable
                         'name',
                         fn ($query) => $query
                             ->where('is_default', 0)
-                            ->whereHas('xlsformModule', fn ($query) => $query->where('name', 'diet_quality'))
+                            ->whereHas('xlsformModule', fn ($query) => $query->where('name', 'diet_diversity'))
                     )
                     ->afterStateUpdated(fn (self $livewire) => $livewire->saveData()),
             ]);
@@ -113,7 +113,8 @@ class DietDiversity extends Page implements HasForms, HasTable
                 TextColumn::make('type')->label('Question Type'),
                 TextColumn::make('name')->label('Name'),
                 TextColumn::make('defaultLabel.text')->label('Label (en)')->wrap(),
-                TextColumn::make('defaultHint.text')->label('Hint (en)')->wrap(),
+                TextColumn::make('defaultHint.text')->label('Hint (en)')->wrap()
+                ->width('40%'),
             ]);
     }
 }

--- a/app/Filament/App/Pages/PlaceAdaptations/DietDiversity.php
+++ b/app/Filament/App/Pages/PlaceAdaptations/DietDiversity.php
@@ -100,7 +100,7 @@ class DietDiversity extends Page implements HasForms, HasTable
         } else {
             //  default to the 'default' diet diversity module version;
             $moduleVersion = XlsformModuleVersion::where('is_default', 1)
-                ->whereHas('xlsformModule', fn ($query) => $query->where('name', 'diet_quality'))
+                ->whereHas('xlsformModule', fn ($query) => $query->where('name', 'diet_diversity'))
                 ->first();
         }
 

--- a/app/Livewire/Lisp/CustomModuleVersions.php
+++ b/app/Livewire/Lisp/CustomModuleVersions.php
@@ -98,7 +98,7 @@ class CustomModuleVersions extends Component implements HasForms
         $file = reset($customQuestionList);
 
         // follow process for importing XlsformTemplates
-        $handler = new HandleXlsformTemplateAdded;
+        $handler = new HandleXlsformTemplateAdded(importedBy: auth()->user());
 
         $moduleVersions = $this->unmatchedLocalIndicators->map(fn(LocalIndicator $localIndicator) => $localIndicator->xlsformModuleVersion);
 

--- a/resources/views/filament/app/pages/place-adaptations/diet-diversity.blade.php
+++ b/resources/views/filament/app/pages/place-adaptations/diet-diversity.blade.php
@@ -11,7 +11,8 @@
                 </p>
                 <p class="mb-2">
                     The platform can incorporate localised versions of the questions from the
-                    <a href="https://www.dietquality.org/tools" class="text-green font-semibold">Global Diet Quality Project</a>, which add relevant example foods for each category customised for over 100 countries. If you would like to include these in your survey, select the suitable country from the list of available countries. The page shows the questions that will appear in the survey, so you can review the default and the localised versions with examples, and decide what to use for your survey.
+                    <a href="https://www.dietquality.org/tools" class="text-green font-semibold" target="_blank"
+                    >Global Diet Quality Project</a>, which add relevant example foods for each category customised for over 100 countries. If you would like to include these in your survey, select the suitable country from the list of available countries. The page shows the questions that will appear in the survey, so you can review the default and the localised versions with examples, and decide what to use for your survey.
                 </p>
             </div>
         </x-slot:instructions>


### PR DESCRIPTION
Adds extra support for custom diet diversity module versions:

- Updates ODK Link package
- When the team is saved with a new dd module version ID, it triggers an update for the team's Xlsforms:
   - any form with a module version linked to the "diet diversity" module is updated; the existing diet diversity module version is removed and the new one is added. 
- Adds a custom resource in the admin panel to add / manage diet diversity module versions (XlsformModuleVersion resource, but filtered to only show DD versions)
- minor fixes to the front-end page.
